### PR TITLE
Unzip archive.zip in extra folder

### DIFF
--- a/opt/cae/deployment.sh
+++ b/opt/cae/deployment.sh
@@ -156,11 +156,13 @@ last_char=${JENKINS_URL:length-1:1}
 
 if [ $last_char = "/" ]; then
   # last char is slash
-  wget ${JENKINS_URL}job/$BUILD_JOB_NAME/lastSuccessfulBuild/artifact/*zip*/archive.zip && unzip archive.zip && cd "$ARCHIVE_DIR"
+  wget ${JENKINS_URL}job/$BUILD_JOB_NAME/lastSuccessfulBuild/artifact/*zip*/archive.zip
 else
   # last char is no slash
-  wget ${JENKINS_URL}/job/$BUILD_JOB_NAME/lastSuccessfulBuild/artifact/*zip*/archive.zip && unzip archive.zip && cd "$ARCHIVE_DIR"
+  wget ${JENKINS_URL}/job/$BUILD_JOB_NAME/lastSuccessfulBuild/artifact/*zip*/archive.zip
 fi
+
+unzip -d archive archive.zip && cd "$ARCHIVE_DIR"
 
 echo "Starting microservices now..."
 for D in ./microservice-*; do


### PR DESCRIPTION
The deployment.sh file always used "unzip archive.zip" to unzip the archive from Jenkins and the files/folders were unzipped into a separate folder "/build/archive". Whyever, this is not the case anymore and the files are directly extracted into the "/build" folder. This breaks the deployment.
This PR adds a flag to the unzip call and then the files/folders are again extracted into "/build/archive" folder.

I could not find any information that the "unzip" command has changed in the past weeks or months (or even years). This makes everything very confusing, because it previously worked well.