### PR TITLE
Java 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM adoptopenjdk/openjdk14:jdk-14.0.2_12-debian
 
 # Let the container know that there is no tty
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
The deployment docker image previously used openjdk:8-jdk as a base image.
To get JDK 14 working as fast as possible (without lots of changes needed), I decided to use adoptopenjdk/openjdk14:jdk-14.0.2_12-debian as a new base image (https://github.com/rwth-acis/cae-deployment/commit/8250afe5fe5ca5b71eddf9b6a24ef9cde9ac7bca).
The alternative would have been openjdk:14 of course, but there they use a different base image than the one used in openjdk:8-jdk which would lead to lots of changes required for the Dockerfile setup.